### PR TITLE
Update package.json to fix >

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/lab": "5.0.0-alpha.134",
     "@mui/material": "^5.13.6",
-    "@typescript-eslint/eslint-plugin": "^5.60.0",
+    "@typescript-eslint/eslint-plugin": "^6.4.1",
     "@vercel/analytics": "^1.0.1",
     "axios": "^1.4.0",
     "framer-motion": "^10.16.2",


### PR DESCRIPTION
Error: Parsing error: DeprecationError: 'originalKeywordKind' has been deprecated since v5.0.0 and can no longer be used. Use 'identifierToKeywordKind(identifier)' instead.